### PR TITLE
$cfg_include_path should depend on package

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -27,10 +27,11 @@ class powerdns::package(
   }
 
   file { $cfg_include_path :
-    ensure => directory,
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0755',
+    ensure  => directory,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0755',
+    require => Package[$package],
   }
 
 }


### PR DESCRIPTION
The package should be installed before creating $cfg_include_path. Because if $cfg_include_path is a sub directory of a directory created by the package it could fail:

```
:~ >puppet agent --test
Info: Retrieving plugin
Info: Caching catalog for example.com
Info: Applying configuration version '1410810293'
Error: Cannot create /etc/powerdns/pdns.d; parent directory /etc/powerdns does not exist
Error: /Stage[main]/Powerdns::Package/File[/etc/powerdns/pdns.d]/ensure: change from absent to directory failed: Cannot create /etc/powerdns/pdns.d; parent directory /etc/powerdns does not exist
Notice: /Stage[main]/Powerdns::Package/Package[pdns-server]/ensure: ensure changed 'purged' to 'present'
Notice: /Stage[main]/Powerdns::Mysql/File[/etc/powerdns/pdns.d/pdns.local.mysql]: Dependency File[/etc/powerdns/pdns.d] has failures: true
Warning: /Stage[main]/Powerdns::Mysql/File[/etc/powerdns/pdns.d/pdns.local.mysql]: Skipping because of failed dependencies
Notice: /Stage[main]/Powerdns::Mysql/Package[pdns-backend-mysql]/ensure: ensure changed 'purged' to 'present'
Notice: /Stage[main]/Powerdns::Service/Service[pdns]: Dependency File[/etc/powerdns/pdns.d] has failures: true
Warning: /Stage[main]/Powerdns::Service/Service[pdns]: Skipping because of failed dependencies
Notice: /Stage[main]/Powerdns/Anchor[powerdns::end]: Dependency File[/etc/powerdns/pdns.d] has failures: true
Warning: /Stage[main]/Powerdns/Anchor[powerdns::end]: Skipping because of failed dependencies
Notice: Finished catalog run in 15.41 seconds
```
