### PR TITLE
add ability to pass package name

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,8 +20,9 @@ class powerdns(
   }
 
   class { 'powerdns::package':
-    ensure => $ensure,
-    source => $source
+    ensure  => $ensure,
+    source  => $source,
+    package => $package,
   }
 
   class { 'powerdns::service':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,8 @@
 #
 class powerdns(
   $ensure = 'present',
-  $source = ''
+  $source = '',
+  $package = $powerdns::params::package
 ) {
 
   anchor { 'powerdns::begin': ;


### PR DESCRIPTION
Quick fix to support passing a package name.

My use case is:

```puppet
  include apt
  include apt::backports
  class { 'powerdns':
    ensure  => present,
    package => 'pdns-server/wheezy-backports', #force to install pdns from backport repo
    require => [ Btngmysql::Db::Setup['pdns'], Class['apt::backports'] ],
  }
```