### PR TITLE
Allow purging unmanaged configuration

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,8 +1,9 @@
 # Public: Install the powerdns server
 #
-# ensure - Ensure powerdns to be present or absent
-# source - Source package of powerdns server,
-#          default is package provider
+# ensure       - Ensure powerdns to be present or absent
+# source       - Source package of powerdns server,
+#                default is package provider
+# purge_config - Delete configuration files which are not managed with powerdns::config
 #
 # Example:
 #
@@ -10,8 +11,9 @@
 #    include powerdns
 #
 class powerdns(
-  $ensure = 'present',
-  $source = ''
+  $ensure       = 'present',
+  $source       = '',
+  $purge_config = false,
 ) {
 
   anchor { 'powerdns::begin': ;
@@ -19,8 +21,9 @@ class powerdns(
   }
 
   class { 'powerdns::package':
-    ensure => $ensure,
-    source => $source
+    ensure       => $ensure,
+    source       => $source,
+    purge_config => $purge_config,
   }
 
   class { 'powerdns::service':

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -5,9 +5,10 @@
 #    include powerdns::package
 #
 class powerdns::package(
-  $package = $powerdns::params::package,
-  $ensure = 'present',
-  $source = ''
+  $package      = $powerdns::params::package,
+  $ensure       = 'present',
+  $source       = '',
+  $purge_config = false,
 ) inherits powerdns::params {
 
   $package_source = $source ? {
@@ -31,6 +32,8 @@ class powerdns::package(
     owner   => 'root',
     group   => 'root',
     mode    => '0755',
+    recurse => $purge_config,
+    purge   => $purge_config,
     require => Package[$package],
   }
 

--- a/spec/classes/powerdns__mysql_spec.rb
+++ b/spec/classes/powerdns__mysql_spec.rb
@@ -7,7 +7,7 @@ describe 'powerdns::mysql', :type => :class do
   end
 
   it do
-    should contain_file('/etc/powerdns/pdns.d/pdns.local.mysql').with_ensure('present')
+    should contain_file('/etc/powerdns/pdns.d/pdns.local.gmysql.conf').with_ensure('present')
   end
 
 end

--- a/spec/classes/powerdns__package_spec.rb
+++ b/spec/classes/powerdns__package_spec.rb
@@ -3,5 +3,11 @@ require 'spec_helper'
 describe 'powerdns::package', :type => :class do
 
   it { should contain_package('pdns-server').with_ensure('present') }
+  it { should contain_file('/etc/powerdns/pdns.d').with_ensure('directory').with_purge(false) }
 
+  context 'with purge_config=true' do
+    let(:params) { { purge_config: true } }
+
+    it { should contain_file('/etc/powerdns/pdns.d').with_purge(true) }
+  end
 end

--- a/spec/classes/powerdns__postgresql_spec.rb
+++ b/spec/classes/powerdns__postgresql_spec.rb
@@ -7,7 +7,7 @@ describe 'powerdns::postgresql', :type => :class do
   end
 
   it do
-    should contain_file('/etc/powerdns/pdns.d/pdns.local.gpgsql').with_ensure('present')
+    should contain_file('/etc/powerdns/pdns.d/pdns.local.gpgsql.conf').with_ensure('present')
   end
 
   describe 'should include correct schema when dnssec is yes' do

--- a/spec/classes/powerdns_spec.rb
+++ b/spec/classes/powerdns_spec.rb
@@ -5,4 +5,12 @@ describe 'powerdns', :type => :class do
   it { should include_class('powerdns::package') }
   it { should include_class('powerdns::service') }
 
+  context 'with purge_config=true' do
+    let(:params) { { purge_config: true } }
+
+    it 'should pass purge_config to powerdns::package' do
+      should contain_class('powerdns::package').with_purge_config(true)
+    end
+  end
+
 end

--- a/spec/defines/powerdns__config_spec.rb
+++ b/spec/defines/powerdns__config_spec.rb
@@ -9,8 +9,8 @@ describe 'powerdns::config', :type => :define do
     'ensure'  => 'present',
     'owner'   => 'root',
     'group'   => 'root',
-    'mode'    => '0700',
-    'content' => "cache-ttl=20"
+    'mode'    => '0600',
+    'content' => "cache-ttl=20\n"
   ) end
 
 end


### PR DESCRIPTION
Added a parameter to the `powerdns` class that deletes all unmanaged powerdns configuration files under `/etc/powerdns/pdns.d`.

On my server (Ubuntu Trusty), the OS ships with a couple of configuration files that should be deleted when puppet first runs.

This also allows you to delete a `powerdns::config` resource from your puppet manifest and have it be removed from your filesystem when you run puppet.


I also fixed a bunch of specs that failed on my machine (I think the manifests had been changed but the specs weren't updated)