### PR TITLE
Do not send sensitive data to the reporting engine

### DIFF
--- a/manifests/mysql.pp
+++ b/manifests/mysql.pp
@@ -40,13 +40,14 @@ class powerdns::mysql(
   }
 
   file { $powerdns::params::mysql_cfg_path:
-    ensure  => $ensure,
-    owner   => root,
-    group   => root,
-    mode    => '0600',
-    backup  => '.bak',
-    content => template('powerdns/pdns.mysql.local.erb'),
-    notify  => Service['pdns'],
-    require => Package[$powerdns::params::package],
+    ensure    => $ensure,
+    owner     => root,
+    group     => root,
+    mode      => '0600',
+    show_diff => false,
+    backup    => '.bak',
+    content   => template('powerdns/pdns.mysql.local.erb'),
+    notify    => Service['pdns'],
+    require   => Package[$powerdns::params::package],
   }
 }

--- a/manifests/postgresql.pp
+++ b/manifests/postgresql.pp
@@ -45,14 +45,15 @@ class powerdns::postgresql(
   }
 
   file { $powerdns::params::postgresql_cfg_path:
-    ensure  => $ensure,
-    owner   => root,
-    group   => root,
-    mode    => '0600',
-    backup  => '.bak',
-    content => template('powerdns/pdns.pgsql.local.erb'),
-    notify  => Service['pdns'],
-    require => Package[$powerdns::params::package],
+    ensure    => $ensure,
+    owner     => root,
+    group     => root,
+    mode      => '0600',
+    show_diff => false,
+    backup    => '.bak',
+    content   => template('powerdns/pdns.pgsql.local.erb'),
+    notify    => Service['pdns'],
+    require   => Package[$powerdns::params::package],
   }
 
   file { '/opt/powerdns_schema.sql':


### PR DESCRIPTION
Hi,

I noticed that any change to the database configuration will be reported in tools like foreman. In my configuration the passwords are protected using the eyaml backend, so I don't really want then appearing in foreman as diffs. I think that disabling diff reporting for that particular resource would be a good default for everybody.

Best Regards,
Alex. 