### PR TITLE
Support for pdns 3.4 in postgres and hiera style config

### DIFF
--- a/files/postgresql_schema_3.4.sql
+++ b/files/postgresql_schema_3.4.sql
@@ -1,0 +1,95 @@
+CREATE TABLE domains (
+  id                    SERIAL PRIMARY KEY,
+  name                  VARCHAR(255) NOT NULL,
+  master                VARCHAR(128) DEFAULT NULL,
+  last_check            INT DEFAULT NULL,
+  type                  VARCHAR(6) NOT NULL,
+  notified_serial       INT DEFAULT NULL,
+  account               VARCHAR(40) DEFAULT NULL,
+  CONSTRAINT c_lowercase_name CHECK (((name)::TEXT = LOWER((name)::TEXT)))
+);
+
+CREATE UNIQUE INDEX name_index ON domains(name);
+
+
+CREATE TABLE records (
+  id                    SERIAL PRIMARY KEY,
+  domain_id             INT DEFAULT NULL,
+  name                  VARCHAR(255) DEFAULT NULL,
+  type                  VARCHAR(10) DEFAULT NULL,
+  content               VARCHAR(65535) DEFAULT NULL,
+  ttl                   INT DEFAULT NULL,
+  prio                  INT DEFAULT NULL,
+  change_date           INT DEFAULT NULL,
+  disabled              BOOL DEFAULT 'f',
+  ordername             VARCHAR(255),
+  auth                  BOOL DEFAULT 't',
+  CONSTRAINT domain_exists
+  FOREIGN KEY(domain_id) REFERENCES domains(id)
+  ON DELETE CASCADE,
+  CONSTRAINT c_lowercase_name CHECK (((name)::TEXT = LOWER((name)::TEXT)))
+);
+
+CREATE INDEX rec_name_index ON records(name);
+CREATE INDEX nametype_index ON records(name,type);
+CREATE INDEX domain_id ON records(domain_id);
+CREATE INDEX recordorder ON records (domain_id, ordername text_pattern_ops);
+
+
+CREATE TABLE supermasters (
+  ip                    INET NOT NULL,
+  nameserver            VARCHAR(255) NOT NULL,
+  account               VARCHAR(40) NOT NULL,
+  PRIMARY KEY(ip, nameserver)
+);
+
+
+CREATE TABLE comments (
+  id                    SERIAL PRIMARY KEY,
+  domain_id             INT NOT NULL,
+  name                  VARCHAR(255) NOT NULL,
+  type                  VARCHAR(10) NOT NULL,
+  modified_at           INT NOT NULL,
+  account               VARCHAR(40) DEFAULT NULL,
+  comment               VARCHAR(65535) NOT NULL,
+  CONSTRAINT domain_exists
+  FOREIGN KEY(domain_id) REFERENCES domains(id)
+  ON DELETE CASCADE,
+  CONSTRAINT c_lowercase_name CHECK (((name)::TEXT = LOWER((name)::TEXT)))
+);
+
+CREATE INDEX comments_domain_id_idx ON comments (domain_id);
+CREATE INDEX comments_name_type_idx ON comments (name, type);
+CREATE INDEX comments_order_idx ON comments (domain_id, modified_at);
+
+
+CREATE TABLE domainmetadata (
+  id                    SERIAL PRIMARY KEY,
+  domain_id             INT REFERENCES domains(id) ON DELETE CASCADE,
+  kind                  VARCHAR(32),
+  content               TEXT
+);
+
+CREATE INDEX domainidmetaindex ON domainmetadata(domain_id);
+
+
+CREATE TABLE cryptokeys (
+  id                    SERIAL PRIMARY KEY,
+  domain_id             INT REFERENCES domains(id) ON DELETE CASCADE,
+  flags                 INT NOT NULL,
+  active                BOOL,
+  content               TEXT
+);
+
+CREATE INDEX domainidindex ON cryptokeys(domain_id);
+
+
+CREATE TABLE tsigkeys (
+  id                    SERIAL PRIMARY KEY,
+  name                  VARCHAR(255),
+  algorithm             VARCHAR(50),
+  secret                VARCHAR(255),
+  CONSTRAINT c_lowercase_name CHECK (((name)::TEXT = LOWER((name)::TEXT)))
+);
+
+CREATE UNIQUE INDEX namealgoindex ON tsigkeys(name, algorithm);

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -37,4 +37,14 @@ class powerdns::package(
     require => Package[$package],
   }
 
+  $pdns_config = hiera('pdns::config','')
+  file { "$powerdns::params::cfg_include_path/authoritive.conf":
+    ensure  => present,
+    content => template('powerdns/authoritive-conf.erb'),
+    owner   => 'root',
+    group   => 'root',
+    require => Package[$package],
+    notify  => Class['::powerdns::service']
+  }
+
 }

--- a/manifests/postgresql.pp
+++ b/manifests/postgresql.pp
@@ -16,15 +16,19 @@ class powerdns::postgresql(
   $source   = '',
   $user     = '',
   $password = '',
+  $version  = '',
   $host     = 'localhost',
   $port     = '5432',
   $dbname   = 'pdns',
   $dnssec   = 'yes'
 ) inherits powerdns::params {
 
-  $postgres_schema = $dnssec ? {
-    /(yes|true)/ => 'puppet:///modules/powerdns/postgresql_schema.dnssec.sql',
-    default      => 'puppet:///modules/powerdns/postgresql_schema.sql'
+  if $version == '3.4' {
+    $postgres_schema = 'puppet:///modules/powerdns/postgresql_schema_3.4.sql'
+  } else {
+    $postgres_schema = $dnssec ? {
+      /(yes|true)/ => 'puppet:///modules/powerdns/postgresql_schema.dnssec.sql',
+      default      => 'puppet:///modules/powerdns/postgresql_schema.sql'
   }
 
   $package_source = $source ? {

--- a/manifests/postgresql.pp
+++ b/manifests/postgresql.pp
@@ -29,6 +29,7 @@ class powerdns::postgresql(
     $postgres_schema = $dnssec ? {
       /(yes|true)/ => 'puppet:///modules/powerdns/postgresql_schema.dnssec.sql',
       default      => 'puppet:///modules/powerdns/postgresql_schema.sql'
+    }
   }
 
   $package_source = $source ? {

--- a/templates/authoritive-conf.erb
+++ b/templates/authoritive-conf.erb
@@ -1,0 +1,6 @@
+# This file is managed by Puppet.
+<% if @pdns_config != '' -%>
+<% @pdns_config.each_pair do |key,value| -%>
+<%= key %>=<%= value %> 
+<%end-%>
+<%end-%>

--- a/templates/pdns.mysql.local.erb
+++ b/templates/pdns.mysql.local.erb
@@ -12,7 +12,7 @@ gmysql-dbname=<%= @dbname %>
 gmysql-user=<%= @user %>
 gmysql-password=<%= @password %>
 gmysql-dnssec=<%= @dnssec %>
-<% if @osfamily == "Redhat" %>       
+<% if @osfamily == "RedHat" %>       
 <%= @cfg_include_name %>=<%= @cfg_include_path %>
 <% end %>
 

--- a/templates/pdns.pgsql.local.erb
+++ b/templates/pdns.pgsql.local.erb
@@ -12,6 +12,6 @@ gpgsql-dbname=<%= @dbname %>
 gpgsql-user=<%= @user %>
 gpgsql-password=<%= @password %>
 gpgsql-dnssec=<%= @dnssec %>
-<% if @osfamily == "Redhat" %>
+<% if @osfamily == "RedHat" %>
 <%= @cfg_include_name %>=<%= @cfg_include_path %>
 <% end %>


### PR DESCRIPTION
Hi, made a few modifications to the module which I hope can be used for others too. To summarize, I did the following:

* added support for powerdns authoritive server 3.4 as the DB schema for that version is quite different than what the module provides. (I've only updated postgresql since that's what we're using as a backend.)
* The 3.4 schema is coming straight from the powerdns documentation website
* In addition, I liked the idea of configuring pdns configuration parameters via hiera rather than using the pdns::config define so I added support for that as well. 
* Small typo fix in the template with the osfamily.

All changes should be backward compatible and not break existing deploys.