### PR TITLE
Make config files more idempotent

### DIFF
--- a/manifests/mysql.pp
+++ b/manifests/mysql.pp
@@ -45,9 +45,8 @@ class powerdns::mysql(
     group     => root,
     mode      => '0600',
     show_diff => false,
-    backup    => '.bak',
     content   => template('powerdns/pdns.mysql.local.erb'),
     notify    => Service['pdns'],
-    require   => Package[$powerdns::params::package],
+    require   => [Package[$package], Package[$powerdns::params::package]],
   }
 }


### PR DESCRIPTION
This change ensures that the config files are written after the mysql
package is installed, and any existing config files are simply
overwritten instead of being backed up.  This is needed so that when
purge is turned on for the config directory that no unnecessary files
are created by puppet itself, or package installation making backups.